### PR TITLE
feat: add storefront vendor APIs and vendor product filtering

### DIFF
--- a/Docs/api/storefront.md
+++ b/Docs/api/storefront.md
@@ -7,7 +7,7 @@
 
 **Request**
 - **Route params:** none
-- **Query params:** none
+- **Query params:** supports `filters[vendor_slug]`
 - **Body:** `none`
 
 **Response**
@@ -26,4 +26,27 @@
 
   const { data } = await clientFetch<ProductListResponse>("/api/user/products/v1");
   ```
+
+### VendorsController — GET /api/storefront/v1/vendors
+**Module:** Storefront
+**Auth:** AllowAnonymous
+**Summary:** List public vendors
+
+**Request**
+- **Query params:** supports pagination, search, and `filters[slug]`
+
+**Response**
+- **200 OK:** `VendorListPaginatedResponse`
+
+### VendorsController — GET /api/storefront/v1/vendors/detail
+**Module:** Storefront
+**Auth:** AllowAnonymous
+**Summary:** Get vendor by slug or id
+
+**Request**
+- **Query params:** `slug` or `id`
+
+**Response**
+- **200 OK:** `VendorDetailResponse`
+- **404:** Vendor not found
 

--- a/Docs/source/api.md
+++ b/Docs/source/api.md
@@ -136,3 +136,20 @@ Module: Storefront
 - **Response:** `ProductListResponse`
 - **Auth:** AllowAnonymous
 
+- **Auth:** AllowAnonymous
+
+### VendorsController
+Module: Storefront
+
+- **Endpoint:** `GET /api/storefront/v1/vendors`
+- **Frontend Usage:** Vendor listing
+- **Request:** Query `GridRequest`
+- **Response:** `VendorListPaginatedResponse`
+- **Auth:** AllowAnonymous
+
+- **Endpoint:** `GET /api/storefront/v1/vendors/detail`
+- **Frontend Usage:** Vendor detail
+- **Request:** Query `slug` or `id`
+- **Response:** `VendorDetailResponse`
+- **Auth:** AllowAnonymous
+

--- a/Source/Sky.Template.Backend.Application/Services/Storefront/IStorefrontVendorService.cs
+++ b/Source/Sky.Template.Backend.Application/Services/Storefront/IStorefrontVendorService.cs
@@ -1,0 +1,82 @@
+using Sky.Template.Backend.Contract.Responses.Storefront;
+using Sky.Template.Backend.Core.Aspects.Autofac.Caching;
+using Sky.Template.Backend.Core.BaseResponse;
+using Sky.Template.Backend.Core.Constants;
+using Sky.Template.Backend.Core.Exceptions;
+using Sky.Template.Backend.Core.Requests.Base;
+using Sky.Template.Backend.Infrastructure.Entities.Vendor;
+using Sky.Template.Backend.Infrastructure.Repositories;
+
+namespace Sky.Template.Backend.Application.Services.Storefront;
+
+public interface IStorefrontVendorService
+{
+    Task<BaseControllerResponse<VendorListPaginatedResponse>> GetVendorsAsync(GridRequest request);
+    Task<BaseControllerResponse<VendorDetailResponse>> GetVendorDetailAsync(string? slug, Guid? id);
+}
+
+public class StorefrontVendorService : IStorefrontVendorService
+{
+    private readonly IStorefrontVendorRepository _repository;
+
+    public StorefrontVendorService(IStorefrontVendorRepository repository)
+    {
+        _repository = repository;
+    }
+
+    [Cacheable(CacheKeyPrefix = nameof(CacheKeys.StorefrontVendorsPrefix), ExpirationInMinutes = 2)]
+    public async Task<BaseControllerResponse<VendorListPaginatedResponse>> GetVendorsAsync(GridRequest request)
+    {
+        var (vendors, total) = await _repository.GetVendorsAsync(request);
+        var items = vendors.Select(MapListItem).ToList();
+        var paginated = new PaginatedData<VendorListItemResponse>
+        {
+            Items = items,
+            TotalCount = total,
+            Page = request.Page,
+            PageSize = request.PageSize,
+            TotalPage = (int)Math.Ceiling((double)total / request.PageSize)
+        };
+        return ControllerResponseBuilder.Success(new VendorListPaginatedResponse { Vendors = paginated });
+    }
+
+    [Cacheable(CacheKeyPrefix = nameof(CacheKeys.StorefrontVendorDetailPrefix), ExpirationInMinutes = 2)]
+    public async Task<BaseControllerResponse<VendorDetailResponse>> GetVendorDetailAsync(string? slug, Guid? id)
+    {
+        VendorEntity? vendor = null;
+        if (!string.IsNullOrWhiteSpace(slug))
+            vendor = await _repository.GetActiveBySlugAsync(slug);
+        else if (id.HasValue)
+            vendor = await _repository.GetActiveByIdAsync(id.Value);
+
+        if (vendor == null)
+            throw new NotFoundException("VendorNotFound");
+
+        return ControllerResponseBuilder.Success(MapDetail(vendor));
+    }
+
+    private static VendorListItemResponse MapListItem(VendorWithProductCountEntity v) => new()
+    {
+        Id = v.Id,
+        Name = v.Name,
+        Slug = v.Slug,
+        ShortDescription = v.ShortDescription,
+        LogoUrl = v.LogoUrl,
+        RatingAvg = v.RatingAvg,
+        RatingCount = v.RatingCount,
+        ProductCount = v.ProductCount
+    };
+
+    private static VendorDetailResponse MapDetail(VendorEntity v) => new()
+    {
+        Id = v.Id,
+        Name = v.Name,
+        Slug = v.Slug,
+        ShortDescription = v.ShortDescription,
+        LogoUrl = v.LogoUrl,
+        BannerUrl = v.BannerUrl,
+        RatingAvg = v.RatingAvg,
+        RatingCount = v.RatingCount,
+        CreatedAt = v.CreatedAt
+    };
+}

--- a/Source/Sky.Template.Backend.Contract/Responses/Storefront/VendorDetailResponse.cs
+++ b/Source/Sky.Template.Backend.Contract/Responses/Storefront/VendorDetailResponse.cs
@@ -1,0 +1,14 @@
+namespace Sky.Template.Backend.Contract.Responses.Storefront;
+
+public class VendorDetailResponse
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public string Slug { get; set; } = string.Empty;
+    public string? ShortDescription { get; set; }
+    public string? LogoUrl { get; set; }
+    public string? BannerUrl { get; set; }
+    public decimal RatingAvg { get; set; }
+    public int RatingCount { get; set; }
+    public DateTime CreatedAt { get; set; }
+}

--- a/Source/Sky.Template.Backend.Contract/Responses/Storefront/VendorListItemResponse.cs
+++ b/Source/Sky.Template.Backend.Contract/Responses/Storefront/VendorListItemResponse.cs
@@ -1,0 +1,13 @@
+namespace Sky.Template.Backend.Contract.Responses.Storefront;
+
+public class VendorListItemResponse
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public string Slug { get; set; } = string.Empty;
+    public string? ShortDescription { get; set; }
+    public string? LogoUrl { get; set; }
+    public decimal RatingAvg { get; set; }
+    public int RatingCount { get; set; }
+    public int ProductCount { get; set; }
+}

--- a/Source/Sky.Template.Backend.Contract/Responses/Storefront/VendorListPaginatedResponse.cs
+++ b/Source/Sky.Template.Backend.Contract/Responses/Storefront/VendorListPaginatedResponse.cs
@@ -1,0 +1,8 @@
+using Sky.Template.Backend.Core.BaseResponse;
+
+namespace Sky.Template.Backend.Contract.Responses.Storefront;
+
+public class VendorListPaginatedResponse
+{
+    public PaginatedData<VendorListItemResponse> Vendors { get; set; } = new();
+}

--- a/Source/Sky.Template.Backend.Core/CrossCuttingConcerns/Caching/CacheKeys.cs
+++ b/Source/Sky.Template.Backend.Core/CrossCuttingConcerns/Caching/CacheKeys.cs
@@ -8,6 +8,9 @@ public static class CacheKeys
     public const string ProductsPrefix = $"{Prefix}:products";
     public const string ProductsPattern = $"{Prefix}:products:*";
 
+    public const string StorefrontVendorsPrefix = $"{Prefix}:storefront:vendors";
+    public const string StorefrontVendorDetailPrefix = $"{Prefix}:storefront:vendor";
+
     public const string PermissionsPrefix = $"{Prefix}:permissions";
     public const string PermissionsPattern = $"{Prefix}:permissions:*";
 

--- a/Source/Sky.Template.Backend.Core/Initializer/DatabaseInitializer.cs
+++ b/Source/Sky.Template.Backend.Core/Initializer/DatabaseInitializer.cs
@@ -169,9 +169,15 @@ public static class DatabaseInitializer
                     CREATE TABLE IF NOT EXISTS sys.vendors (
                     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
                     name VARCHAR(255) NOT NULL UNIQUE,
+                    slug TEXT UNIQUE NOT NULL,
+                    short_description TEXT,
+                    logo_url TEXT,
+                    banner_url TEXT,
                     email VARCHAR(255),
                     phone VARCHAR(50),
                     address TEXT,
+                    rating_avg NUMERIC(3,2) DEFAULT 0.00,
+                    rating_count INT DEFAULT 0,
                     status status_enum DEFAULT 'ACTIVE',
                     created_by UUID REFERENCES sys.users(id) ON DELETE SET NULL,
                     updated_by UUID REFERENCES sys.users(id) ON DELETE SET NULL,
@@ -197,6 +203,9 @@ public static class DatabaseInitializer
                       END IF;
                     END;
                     $$;
+
+                    CREATE INDEX IF NOT EXISTS idx_vendors_status ON sys.vendors(status);
+                    CREATE INDEX IF NOT EXISTS idx_vendors_slug ON sys.vendors (lower(slug));
 
 
 
@@ -559,6 +568,7 @@ public static class DatabaseInitializer
                     CREATE INDEX IF NOT EXISTS idx_products_brand ON sys.products(brand_id);
                     CREATE INDEX IF NOT EXISTS idx_products_category ON sys.products(category_id);
                     CREATE INDEX IF NOT EXISTS idx_products_vendor   ON sys.products(vendor_id);
+                    CREATE INDEX IF NOT EXISTS idx_products_vendor_status ON sys.products(vendor_id, status);
                     CREATE INDEX IF NOT EXISTS idx_products_status   ON sys.products(status) WHERE is_deleted = FALSE;
                     CREATE INDEX IF NOT EXISTS idx_products_active   ON sys.products(id) WHERE is_deleted = FALSE AND status = 'ACTIVE';
                     CREATE INDEX IF NOT EXISTS idx_product_trans_pid_lang ON sys.product_translations(product_id, language_code);

--- a/Source/Sky.Template.Backend.Infrastructure/AssemblyInfo.cs
+++ b/Source/Sky.Template.Backend.Infrastructure/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Sky.Template.Backend.UnitTests")]

--- a/Source/Sky.Template.Backend.Infrastructure/Configs/Products/ProductGridFilterConfig.cs
+++ b/Source/Sky.Template.Backend.Infrastructure/Configs/Products/ProductGridFilterConfig.cs
@@ -8,6 +8,7 @@ public static class ProductGridFilterConfig
     {
         { "id",           new ColumnMapping("p.id",            typeof(Guid)) },
         { "vendorId",     new ColumnMapping("p.vendor_id",     typeof(Guid)) },
+        { "vendor_id",    new ColumnMapping("p.vendor_id",     typeof(Guid)) },
         { "name",         new ColumnMapping("COALESCE(pt_lang.name, pt_any.name)", typeof(string)) },
         { "sku",          new ColumnMapping("p.sku",           typeof(string)) },
         { "status",       new ColumnMapping("p.status",        typeof(string)) },
@@ -15,7 +16,8 @@ public static class ProductGridFilterConfig
         { "minPrice",     new ColumnMapping("p.price >= @minPrice", typeof(decimal)) }, // hazır koşul
         { "maxPrice",     new ColumnMapping("p.price <= @maxPrice", typeof(decimal)) }, // hazır koşul
         { "createdAt",    new ColumnMapping("p.created_at",    typeof(DateTime)) },
-        { "slug",         new ColumnMapping("p.slug",          typeof(string)) }
+        { "slug",         new ColumnMapping("p.slug",          typeof(string)) },
+        { "vendor_slug",  new ColumnMapping("LOWER(v.slug)",   typeof(string)) }
     };
 
     public static HashSet<string> GetLikeFilterKeys() => new(StringComparer.OrdinalIgnoreCase)

--- a/Source/Sky.Template.Backend.Infrastructure/Entities/Vendor/VendorEntity.cs
+++ b/Source/Sky.Template.Backend.Infrastructure/Entities/Vendor/VendorEntity.cs
@@ -6,16 +6,57 @@ namespace Sky.Template.Backend.Infrastructure.Entities.Vendor;
 [TableName("vendors")]
 public class VendorEntity : BaseEntity<Guid>, ISoftDeletable
 {
+    [DbManager.mColumn("name")]
     public string Name { get; set; } = string.Empty;
+
+    [DbManager.mColumn("slug")]
+    public string Slug { get; set; } = string.Empty;
+
+    [DbManager.mColumn("short_description")]
+    public string? ShortDescription { get; set; }
+
+    [DbManager.mColumn("logo_url")]
+    public string? LogoUrl { get; set; }
+
+    [DbManager.mColumn("banner_url")]
+    public string? BannerUrl { get; set; }
+
+    [DbManager.mColumn("email")]
     public string? Email { get; set; }
+
+    [DbManager.mColumn("phone")]
     public string? Phone { get; set; }
+
+    [DbManager.mColumn("address")]
     public string? Address { get; set; }
+
+    [DbManager.mColumn("rating_avg")]
+    public decimal RatingAvg { get; set; }
+
+    [DbManager.mColumn("rating_count")]
+    public int RatingCount { get; set; }
+
+    [DbManager.mColumn("status")]
     public string Status { get; set; } = "ACTIVE";
+
+    [DbManager.mColumn("verification_status")]
     public string VerificationStatus { get; set; } = Sky.Template.Backend.Core.Enums.VerificationStatus.PENDING.ToString();
+
+    [DbManager.mColumn("verification_note")]
     public string? VerificationNote { get; set; }
+
+    [DbManager.mColumn("verified_at")]
     public DateTime? VerifiedAt { get; set; }
+
+    [DbManager.mColumn("is_deleted")]
     public bool IsDeleted { get; set; }
+
+    [DbManager.mColumn("deleted_at")]
     public DateTime? DeletedAt { get; set; }
+
+    [DbManager.mColumn("deleted_by")]
     public Guid? DeletedBy { get; set; }
+
+    [DbManager.mColumn("delete_reason")]
     public string? DeleteReason { get; set; }
 }

--- a/Source/Sky.Template.Backend.Infrastructure/Entities/Vendor/VendorWithProductCountEntity.cs
+++ b/Source/Sky.Template.Backend.Infrastructure/Entities/Vendor/VendorWithProductCountEntity.cs
@@ -1,0 +1,10 @@
+using Sky.Template.Backend.Core.Attributes;
+
+namespace Sky.Template.Backend.Infrastructure.Entities.Vendor;
+
+[TableName("vendors")]
+public class VendorWithProductCountEntity : VendorEntity
+{
+    [DbManager.mColumn("product_count")]
+    public int ProductCount { get; set; }
+}

--- a/Source/Sky.Template.Backend.Infrastructure/Repositories/IProductRepository.cs
+++ b/Source/Sky.Template.Backend.Infrastructure/Repositories/IProductRepository.cs
@@ -68,6 +68,16 @@ public class ProductRepository : Repository<ProductEntity, Guid>, IProductReposi
     public async Task<(IEnumerable<ProductLocalizedJoinEntity>, int TotalCount)> GetLocalizedProductsAsync(
     ProductFilterRequest request, bool onlyActive = false)
     {
+        var (sql, builtParams) = BuildLocalizedProductsSql(request, onlyActive);
+        var data = await DbManager.ReadAsync<ProductLocalizedJoinEntity>(sql, builtParams /*, GlobalSchema.Name*/);
+        var countSql = DbManager.Dialect.CountWrap(DbManager.Dialect.StripOrderBy(sql));
+        var count = (await DbManager.ReadAsync<DataCountEntity>(countSql, builtParams /*, GlobalSchema.Name*/))
+                    .FirstOrDefault()?.Count ?? 0;
+        return (data, count);
+    }
+
+    internal (string Sql, Dictionary<string, object> Params) BuildLocalizedProductsSql(ProductFilterRequest request, bool onlyActive)
+    {
         // 0) Dil paramı (Accept-Language -> "tr", "en" ... )
         var languageCode = (_httpContextAccessor.HttpContext?
             .Request.Headers["Accept-Language"].ToString() ?? "en")
@@ -79,7 +89,7 @@ public class ProductRepository : Repository<ProductEntity, Guid>, IProductReposi
         var baseSql = ProductQueries.GetLocalizedProductsAsync + (onlyActive ? " AND p.status = 'ACTIVE'" : "");
 
         // 2) Filtrelerden kategori/subcategory oku (Guid/CSV destekli)
-        request.Filters ??= new Dictionary<string, string>();
+        request.Filters ??= new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         request.Filters.TryGetValue("categoryId", out var catRaw);
         request.Filters.TryGetValue("subcategoryId", out var subRaw);
 
@@ -88,6 +98,15 @@ public class ProductRepository : Repository<ProductEntity, Guid>, IProductReposi
 
         var hasCategory = !string.IsNullOrWhiteSpace(catRaw);
         var hasSubCat = !string.IsNullOrWhiteSpace(subRaw);
+
+        // vendor slug join
+        var hasVendorSlug = request.Filters.TryGetValue("vendor_slug", out var vendorSlug) && !string.IsNullOrWhiteSpace(vendorSlug);
+        if (hasVendorSlug)
+        {
+            request.Filters["vendor_slug"] = vendorSlug!.ToLowerInvariant();
+            baseSql = baseSql.Replace("FROM sys.products p", "FROM sys.products p JOIN sys.vendors v ON v.id = p.vendor_id");
+            baseSql += " AND v.status = 'ACTIVE'";
+        }
 
         // 3) CTE ve WHERE (gerekiyorsa) + paramlar
         var cteParams = new Dictionary<string, object>();
@@ -111,7 +130,6 @@ subcats AS (
 {baseSql}
   AND p.category_id IN (SELECT id FROM subcats)
 ";
-            // Parametreleri her koşulda bağla (boş dizi bile olsa)
             cteParams["@categoryIds"] = catIds.Count > 0 ? catIds.ToArray() : Array.Empty<Guid>();
             cteParams["@subcategoryIds"] = subIds.Count > 0 ? subIds.ToArray() : Array.Empty<Guid>();
         }
@@ -135,16 +153,8 @@ subcats AS (
         builtParams["@lang"] = languageCode;
         foreach (var kv in cteParams) builtParams[kv.Key] = kv.Value;
 
-        // 7) Çalıştır (şema gerekiyorsa üçüncü argümanla ver)
-        var data = await DbManager.ReadAsync<ProductLocalizedJoinEntity>(sql, builtParams /*, GlobalSchema.Name*/);
+        return (sql, builtParams);
 
-        var countSql = DbManager.Dialect.CountWrap(DbManager.Dialect.StripOrderBy(sql));
-        var count = (await DbManager.ReadAsync<DataCountEntity>(countSql, builtParams /*, GlobalSchema.Name*/))
-                    .FirstOrDefault()?.Count ?? 0;
-
-        return (data, count);
-
-        // --- local helpers ---
         static List<Guid> ParseGuids(string? raw)
         {
             var list = new List<Guid>();

--- a/Source/Sky.Template.Backend.Infrastructure/Repositories/IStorefrontVendorRepository.cs
+++ b/Source/Sky.Template.Backend.Infrastructure/Repositories/IStorefrontVendorRepository.cs
@@ -1,0 +1,78 @@
+using Sky.Template.Backend.Core.Context;
+using Sky.Template.Backend.Core.Requests.Base;
+using Sky.Template.Backend.Core.Utilities;
+using Sky.Template.Backend.Infrastructure.Entities;
+using Sky.Template.Backend.Infrastructure.Entities.Vendor;
+using Sky.Template.Backend.Infrastructure.Repositories.DbManagerRepository;
+
+namespace Sky.Template.Backend.Infrastructure.Repositories;
+
+public interface IStorefrontVendorRepository
+{
+    Task<(IEnumerable<VendorWithProductCountEntity> Vendors, int TotalCount)> GetVendorsAsync(GridRequest request);
+    Task<VendorEntity?> GetActiveBySlugAsync(string slug);
+    Task<VendorEntity?> GetActiveByIdAsync(Guid id);
+}
+
+public class StorefrontVendorRepository : IStorefrontVendorRepository
+{
+    private readonly GridQueryConfig<VendorWithProductCountEntity> _config = new()
+    {
+        BaseSql = "SELECT v.*, (SELECT COUNT(1) FROM sys.products p WHERE p.vendor_id = v.id AND p.status = 'ACTIVE') AS product_count FROM sys.vendors v WHERE v.is_deleted = FALSE",
+        DefaultOrderBy = "v.created_at DESC",
+        ColumnMappings = new Dictionary<string, ColumnMapping>(StringComparer.OrdinalIgnoreCase)
+        {
+            { "id",           new ColumnMapping("v.id",          typeof(Guid)) },
+            { "name",         new ColumnMapping("v.name",        typeof(string)) },
+            { "slug",         new ColumnMapping("v.slug",        typeof(string)) },
+            { "status",       new ColumnMapping("v.status",      typeof(string)) },
+            { "created_at",   new ColumnMapping("v.created_at",  typeof(DateTime)) },
+            { "product_count",new ColumnMapping("product_count", typeof(int)) }
+        },
+        LikeFilterKeys = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "name", "slug" },
+        SearchColumns = new List<string>{ "v.name", "v.slug", "v.short_description" }
+    };
+
+    internal (string Sql, Dictionary<string, object> Params) BuildListSql(GridRequest request)
+    {
+        request.Filters ??= new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        if (!request.Filters.ContainsKey("status"))
+            request.Filters["status"] = "ACTIVE";
+        if (request.Filters.TryGetValue("slug", out var slug))
+            request.Filters["slug"] = slug.ToLowerInvariant();
+
+        var (sql, parameters) = GridQueryBuilder.Build(
+            _config.BaseSql,
+            request,
+            _config.ColumnMappings,
+            _config.DefaultOrderBy,
+            _config.LikeFilterKeys,
+            _config.SearchColumns,
+            DbManager.Dialect
+        );
+        return (sql, parameters);
+    }
+
+    public async Task<(IEnumerable<VendorWithProductCountEntity> Vendors, int TotalCount)> GetVendorsAsync(GridRequest request)
+    {
+        var (sql, parameters) = BuildListSql(request);
+        var data = await DbManager.ReadAsync<VendorWithProductCountEntity>(sql, parameters, GlobalSchema.Name);
+        var countSql = DbManager.Dialect.CountWrap(DbManager.Dialect.StripOrderBy(sql));
+        var count = (await DbManager.ReadAsync<DataCountEntity>(countSql, parameters, GlobalSchema.Name)).FirstOrDefault()?.Count ?? 0;
+        return (data, count);
+    }
+
+    public async Task<VendorEntity?> GetActiveBySlugAsync(string slug)
+    {
+        const string sql = "SELECT * FROM sys.vendors v WHERE v.is_deleted = FALSE AND v.status = 'ACTIVE' AND lower(v.slug) = lower(@slug) LIMIT 1";
+        var result = await DbManager.ReadAsync<VendorEntity>(sql, new Dictionary<string, object> { { "@slug", slug } }, GlobalSchema.Name);
+        return result.FirstOrDefault();
+    }
+
+    public async Task<VendorEntity?> GetActiveByIdAsync(Guid id)
+    {
+        const string sql = "SELECT * FROM sys.vendors v WHERE v.is_deleted = FALSE AND v.status = 'ACTIVE' AND v.id = @id LIMIT 1";
+        var result = await DbManager.ReadAsync<VendorEntity>(sql, new Dictionary<string, object> { { "@id", id } }, GlobalSchema.Name);
+        return result.FirstOrDefault();
+    }
+}

--- a/Source/Sky.Template.Backend.WebAPI/Controllers/Storefront/StorefrontVendorsController.cs
+++ b/Source/Sky.Template.Backend.WebAPI/Controllers/Storefront/StorefrontVendorsController.cs
@@ -1,0 +1,39 @@
+using System.Text.RegularExpressions;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Sky.Template.Backend.Application.Services.Storefront;
+using Sky.Template.Backend.Core.Requests.Base;
+using Sky.Template.Backend.WebAPI.Controllers.Base;
+
+namespace Sky.Template.Backend.WebAPI.Controllers.Storefront;
+
+[ApiController]
+[Route("api/storefront/v{version:apiVersion}/vendors")]
+[ApiVersion("1.0")]
+public class StorefrontVendorsController : CustomBaseController
+{
+    private readonly IStorefrontVendorService _service;
+
+    public StorefrontVendorsController(IStorefrontVendorService service)
+    {
+        _service = service;
+    }
+
+    [AllowAnonymous]
+    [HttpGet]
+    [MapToApiVersion("1")]
+    public async Task<IActionResult> GetVendors([FromQuery] GridRequest request)
+        => await HandleServiceResponseAsync(() => _service.GetVendorsAsync(request));
+
+    [AllowAnonymous]
+    [HttpGet("detail")]
+    [MapToApiVersion("1")]
+    public async Task<IActionResult> GetVendorDetail([FromQuery] string? slug, [FromQuery] Guid? id)
+    {
+        if (string.IsNullOrWhiteSpace(slug) && !id.HasValue)
+            return BadRequest("SlugOrIdRequired");
+        if (!string.IsNullOrWhiteSpace(slug) && !Regex.IsMatch(slug, "^[a-z0-9-]+$"))
+            return BadRequest("InvalidSlug");
+        return await HandleServiceResponseAsync(() => _service.GetVendorDetailAsync(slug, id));
+    }
+}

--- a/Test/Sky.Template.Backend.UnitTests/ProductRepositoryVendorFilterTests.cs
+++ b/Test/Sky.Template.Backend.UnitTests/ProductRepositoryVendorFilterTests.cs
@@ -1,0 +1,28 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Sky.Template.Backend.Contract.Requests.Products;
+using Sky.Template.Backend.Infrastructure.Repositories;
+using Xunit;
+
+namespace Sky.Template.Backend.UnitTests;
+
+public class ProductRepositoryVendorFilterTests
+{
+    [Fact]
+    public void BuildLocalizedProductsSql_WithVendorSlug_JoinsVendor()
+    {
+        var accessor = new HttpContextAccessor { HttpContext = new DefaultHttpContext() };
+        accessor.HttpContext!.Request.Headers["Accept-Language"] = "en";
+        var repo = new ProductRepository(accessor);
+        var request = new ProductFilterRequest
+        {
+            Page = 1,
+            PageSize = 10,
+            Filters = new Dictionary<string, string> { { "vendor_slug", "acme" } }
+        };
+        var (sql, prms) = repo.BuildLocalizedProductsSql(request, true);
+        sql.Should().Contain("JOIN sys.vendors v ON v.id = p.vendor_id");
+        sql.Should().Contain("LOWER(v.slug) = @vendor_slug");
+        prms.Should().ContainKey("@vendor_slug").WhoseValue.Should().Be("acme");
+    }
+}

--- a/Test/Sky.Template.Backend.UnitTests/StorefrontVendorRepositoryTests.cs
+++ b/Test/Sky.Template.Backend.UnitTests/StorefrontVendorRepositoryTests.cs
@@ -1,0 +1,29 @@
+using FluentAssertions;
+using Sky.Template.Backend.Core.Requests.Base;
+using Sky.Template.Backend.Infrastructure.Repositories;
+using Xunit;
+
+namespace Sky.Template.Backend.UnitTests;
+
+public class StorefrontVendorRepositoryTests
+{
+    [Fact]
+    public void BuildListSql_DefaultsAndSupportsFeatures()
+    {
+        var repo = new StorefrontVendorRepository();
+        var request = new GridRequest
+        {
+            Page = 2,
+            PageSize = 5,
+            SearchValue = "acme",
+            OrderColumn = "product_count",
+            OrderDirection = "ASC"
+        };
+        var (sql, prms) = repo.BuildListSql(request);
+        sql.Should().Contain("v.status = @status");
+        prms.Should().ContainKey("@status").WhoseValue.Should().Be("ACTIVE");
+        sql.Should().Contain("ORDER BY product_count ASC");
+        prms.Should().ContainKey("@Offset").WhoseValue.Should().Be(5);
+        prms.Should().ContainKey("@Search_v_name").WhoseValue.Should().Be("%acme%");
+    }
+}

--- a/Test/Sky.Template.Backend.UnitTests/StorefrontVendorServiceTests.cs
+++ b/Test/Sky.Template.Backend.UnitTests/StorefrontVendorServiceTests.cs
@@ -1,0 +1,46 @@
+using FluentAssertions;
+using Moq;
+using Sky.Template.Backend.Application.Services.Storefront;
+using Sky.Template.Backend.Contract.Responses.Storefront;
+using Sky.Template.Backend.Core.Exceptions;
+using Sky.Template.Backend.Core.Requests.Base;
+using Sky.Template.Backend.Infrastructure.Entities.Vendor;
+using Sky.Template.Backend.Infrastructure.Repositories;
+using Xunit;
+
+namespace Sky.Template.Backend.UnitTests;
+
+public class StorefrontVendorServiceTests
+{
+    [Fact]
+    public async Task GetVendorDetail_BySlug_ReturnsMapped()
+    {
+        var repo = new Mock<IStorefrontVendorRepository>();
+        var entity = new VendorEntity
+        {
+            Id = Guid.NewGuid(),
+            Name = "Acme",
+            Slug = "acme",
+            ShortDescription = "short",
+            LogoUrl = "logo",
+            BannerUrl = "banner",
+            RatingAvg = 4.5m,
+            RatingCount = 10,
+            CreatedAt = new DateTime(2024,1,1)
+        };
+        repo.Setup(r => r.GetActiveBySlugAsync("acme")).ReturnsAsync(entity);
+        var service = new StorefrontVendorService(repo.Object);
+        var response = await service.GetVendorDetailAsync("acme", null);
+        response.Data!.Slug.Should().Be("acme");
+        response.Data.RatingCount.Should().Be(10);
+    }
+
+    [Fact]
+    public async Task GetVendorDetail_NotFound_Throws()
+    {
+        var repo = new Mock<IStorefrontVendorRepository>();
+        repo.Setup(r => r.GetActiveBySlugAsync("missing")).ReturnsAsync((VendorEntity?)null);
+        var service = new StorefrontVendorService(repo.Object);
+        await Assert.ThrowsAsync<NotFoundException>(() => service.GetVendorDetailAsync("missing", null));
+    }
+}


### PR DESCRIPTION
## Summary
- add vendors table enhancements with slug and rating fields plus indexes
- introduce storefront vendor listing/detail endpoints with caching
- allow product list filtering by vendor slug or id

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc2d5593f4833092fcb3f688767829